### PR TITLE
fix(git): force `LC_ALL=C` when calling the `git` CLI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,8 @@ jobs:
           experimental: true
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Install extra dependencies for tests
+        run: sudo apt-get install --yes language-pack-fr
       - name: Get Go directories
         id: go
         run: |

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -3,7 +3,6 @@
 package git_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestGit(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// test clone
 	dir, err := git.Clone(ctx, "main", "https://github.com/jaredallard/jaredallard")
@@ -51,4 +50,20 @@ func TestGit(t *testing.T) {
 		_, err = os.Stat(filepath.Join(dir, ".git"))
 		assert.ErrorContains(t, err, "no such file or directory")
 	})
+}
+
+// Makes sure that GetDefaultBranch works correctly even when the system language is not set to English.
+// Not parallel because it sets an environment variable.
+func TestGetDefaultBranchDifferentOSLanguage(t *testing.T) {
+	ctx := t.Context()
+
+	dir, err := git.Clone(ctx, "main", "https://github.com/jaredallard/jaredallard")
+	assert.NilError(t, err)
+
+	assert.Assert(t, dir != "", "expected a directory to be returned")
+
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	defaultBranch, err := git.GetDefaultBranch(ctx, dir)
+	assert.NilError(t, err)
+	assert.Equal(t, defaultBranch, "main", "Expected default branch to be 'main'")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaredallard/vcs
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Problem

If a user sets their `LC_ALL` to a non-English value, and that language has a translation file for `git`, `git.DefaultBranch` will fail since it's [searching using the English output](https://github.com/jaredallard/vcs/blob/aec6089bfd68839472b6bba467b203c92e572400/git/git.go#L51).

## Solution

When invoking `git`, always set `LC_ALL=C`, which forces `git` to default to a non-translated version.

## Alternatives considered

Port to `go-git` - too much of a lift right now. If Jared wishes to do so in the future, there will be a version of this in `getoutreach/stencil` to copy from.

## Notes for reviewers

I set `go` to `1.24.0` so I could get `testing.T#Context()`. Let me know if that's not desired, and I'll revert it.